### PR TITLE
propose mapping to search for keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,20 @@ require("lazy").setup({
 Use `:help <tag>`. It works for both Vim and Nvim. In Vim you can also use
 `:Help <tag>`. It filters only Python documentation.
 
-In Vim, if you set `g:pythondoc_hh_expand = 1`, you can use `:hh <tag>` instead of `:Help <tag>`.
+In Vim, if you set `g:pythondoc_h_expand = 1`, you can use `:h <tag>` instead of `:Help <tag>`.
+Add
+
+```vim
+exe 'nnoremap <buffer> dK :<c-u>Help <c-r><c-w>'..nr2char(&wildcharm)
+```
+
+to `ftplugin/python.vim` to search for the keyword under the cursor by hitting `dK`.
+
 This is easier to type. If you decide to put all our settings in after/ftplugin directory, then setting the above global variable is done too late. You could do the following:
 
 ```
 import 'pythondoc_abbrev.vim' as abbrev
-abbrev.ExpandHH()
+abbrev.ExpandH()
 ```
 
 You can activate the `wildmenu` for <Tab> completion. You can type `:Help foo<tab>`

--- a/ftplugin/python_doc.vim
+++ b/ftplugin/python_doc.vim
@@ -1,5 +1,6 @@
 command! -buffer -nargs=1 -complete=customlist,s:getHelpTags Help help <args>
 
+" " reserve to pydoc since `:help` leads to Vim9script doc, say on `import`
 " setlocal keywordprg=:Help
 
 silent! fun s:shortestFirst(x, y)
@@ -27,16 +28,16 @@ silent! fun s:getHelpTags(argLead, line, cursorPos)
     return matching->extend(nonmatch)
 endfun
 
-if get(g:, 'pythondoc_hh_expand')
-    silent! fun s:canExpandHH()
+if get(g:, 'pythondoc_h_expand')
+    silent! fun s:canExpandH()
         if getcmdtype() == ':'
             let context = getcmdline()->strpart(0, getcmdpos() - 1)
-            if context == 'hh'
+            if context == 'h'
                 return 1
             endif
         endif
         return 0
     endfun
 
-    cabbr <buffer> <expr> hh     <SID>canExpandHH() ? 'Help' : 'hh'
+    cabbr <buffer> <expr> h     <SID>canExpandH() ? 'Help' : 'h'
 endif


### PR DESCRIPTION
I think `h` can be used for `:Help` in python files, there's still `:h[elp]` and `:tab h`.
Propose a mapping for faster lookup.